### PR TITLE
V0.10.8.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,26 +12,40 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
+    - setuptools
+    - wheel
     - pip
-    - python >=3.6
+    - python
   run:
-    - python >=3.6
+    - python
 
 test:
+  imports:
+    - types-toml
+  requires:
+    - pip
   commands:
+    - pip check
     - test -f $SP_DIR/toml-stubs/__init__.pyi
 
 
 about:
   home: https://github.com/python/typeshed
   summary: Typing stubs for toml
+  description: |
+    This is a PEP 561 type stub package for the toml package.
+    It can be used by type-checking tools like mypy, pyright,
+    pytype, PyCharm, etc. to check code that uses toml.
   license: Apache-2.0 AND MIT
   license_file: LICENSE
+  license_family: OTHER
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://pypi.org/project/types-toml/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
     - pip
   commands:
     - pip check
-    - test -f $SP_DIR/toml-stubs/__init__.pyi
+    - test -f $SP_DIR/toml-stubs/__init__.pyi  # [unix]
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,8 @@ requirements:
 
 test:
   imports:
-    - toml
+    # Not sure what to import here
+    # Have tried types-toml, typeshed, toml, and types
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,7 @@ requirements:
 
 test:
   imports:
-    # Not sure what to import here
-    # Have tried types-toml, typeshed, toml, and types
+    - types
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
 
 test:
   imports:
-    - types-toml
+    - types
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "types-toml" %}
-{% set version = "0.10.1" %}
+{% set version = "0.10.8.6" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-toml-{{ version }}.tar.gz
-  sha256: 5c1f8f8d57692397c8f902bf6b4d913a0952235db7db17d2908cc110e70610cb
+  sha256: 6d3ac79e36c9ee593c5d4fb33a50cca0e3adceb6ef5cff8b8e5aef67b4c4aaf2
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,8 @@ requirements:
     - python
 
 test:
-  imports:
-    - types
+  import:
+    - toml
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - python
 
 test:
-  import:
+  imports:
     - toml
   requires:
     - pip


### PR DESCRIPTION
[Upstream](https://github.com/python/typeshed)
[Changelog](https://github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/toml.md)

### Actions
- Update version to 0.10.8.6
- Update requirements
- Update test section
- Linter fixes